### PR TITLE
Enabling plain text mode

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --features plain_text
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,6 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
- 
+    - name: Run tests for plain_text
+      run: cargo test --verbose --features plain_text
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-tunnel"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Eugene Retunsky"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ time = "0.1"
 [dev-dependencies]
 tokio-test = "0.4"
 
-[profile.dev]
-opt-level = 0
-
-[profile.release]
-opt-level = 3
+[features]
+# For legacy software you can enable plain_text tunnelling
+default = []
+plain_text = []

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The core code is entirely abstract from the tunnel protocol or transport protoco
 In this example, it supports both `HTTP` and `HTTPS` with minimal additional code.
 
 *Please note*, this tunnel doesn't allow tunneling of plain text over HTTP tunnels (only HTTPS connections can be tunneled).
+If you need this functionality you need to build the `http-tunnel` with the `plain_text` feature:
+
+```bash
+cargo build --release --features plain_text
+```
 
 E.g. it can be extended to run the tunnel over `QUIC+HTTP/3` or connect to another tunnel (as long as `AsyncRead + AsyncWrite` is satisfied for the implementation).
 

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -196,10 +196,9 @@ impl HttpConnectRequest {
         const HOST_HEADER: &str = "host:";
 
         lines
-            .into_iter()
             .find(|line| line.to_ascii_lowercase().starts_with(HOST_HEADER))
             .map(|line| String::from(line[HOST_HEADER.len()..].trim()))
-            .and_then(|mut host| {
+            .map(|mut host| {
                 if host.rfind(':').is_none() {
                     host.push_str(if endpoint.starts_with("https://") {
                         ":443"
@@ -207,7 +206,7 @@ impl HttpConnectRequest {
                         ":80"
                     });
                 }
-                Some(host)
+                host
             })
     }
 

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -300,7 +300,9 @@ mod tests {
         EstablishTunnelResult, HttpTunnelCodec, HttpTunnelCodecBuilder, HttpTunnelTargetBuilder,
         MAX_HTTP_REQUEST_SIZE, REQUEST_END_MARKER,
     };
+    #[cfg(feature = "plain_text")]
     use crate::proxy_target::Nugget;
+    #[cfg(feature = "plain_text")]
     use crate::tunnel::EstablishTunnelResult::Forbidden;
     use crate::tunnel::TunnelCtxBuilder;
 

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -10,7 +10,6 @@ use std::fmt::Write;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use log::debug;
-use log::info;
 use regex::Regex;
 use tokio::io::{Error, ErrorKind};
 use tokio_util::codec::{Decoder, Encoder};
@@ -158,8 +157,6 @@ impl HttpConnectRequest {
 
         let http_request_as_string =
             String::from_utf8(http_request.to_vec()).expect("Contains only ASCII");
-
-        info!("Request: {}", http_request_as_string);
 
         let mut lines = http_request_as_string.split("\r\n");
 

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -193,21 +193,22 @@ impl HttpConnectRequest {
     }
 
     fn extract_destination_host(lines: &mut Split<&str>, endpoint: &str) -> Option<String> {
-        let host_header = "host:";
-        for line in lines {
-            if line.to_ascii_lowercase().starts_with(host_header) {
-                let mut host = String::from(line[host_header.len()..].trim());
+        const HOST_HEADER: &str = "host:";
+
+        lines
+            .into_iter()
+            .find(|line| line.to_ascii_lowercase().starts_with(HOST_HEADER))
+            .map(|line| String::from(line[HOST_HEADER.len()..].trim()))
+            .and_then(|mut host| {
                 if host.rfind(':').is_none() {
-                    if endpoint.contains("https://") {
-                        host.push_str(":443");
+                    host.push_str(if endpoint.starts_with("https://") {
+                        ":443"
                     } else {
-                        host.push_str(":80");
-                    }
+                        ":80"
+                    });
                 }
-                return Some(host);
-            }
-        }
-        None
+                Some(host)
+            })
     }
 
     fn parse_request_line(

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -19,12 +19,11 @@ use core::fmt;
 use std::str::Split;
 
 const REQUEST_END_MARKER: &[u8] = b"\r\n\r\n";
-/// A reasonable value to limit possible header size
-/// as long as we only need to support `CONNECT` requests.
-const MAX_HTTP_REQUEST_SIZE: usize = 1024;
+/// A reasonable value to limit possible header size.
+const MAX_HTTP_REQUEST_SIZE: usize = 16384;
 
 /// HTTP/1.1 request representation
-/// Supports only `CONNECT` method
+/// Supports only `CONNECT` method, unless the `plain_text` feature is enabled
 struct HttpConnectRequest {
     uri: String,
     nugget: Option<Nugget>,

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -197,14 +197,16 @@ impl HttpConnectRequest {
 
         lines
             .find(|line| line.to_ascii_lowercase().starts_with(HOST_HEADER))
-            .map(|line| String::from(line[HOST_HEADER.len()..].trim()))
-            .map(|mut host| {
+            .map(|line| line[HOST_HEADER.len()..].trim())
+            .map(|host| {
+                let mut host = String::from(host);
                 if host.rfind(':').is_none() {
-                    host.push_str(if endpoint.starts_with("https://") {
+                    let default_port = if endpoint.to_ascii_lowercase().starts_with("https://") {
                         ":443"
                     } else {
                         ":80"
-                    });
+                    };
+                    host.push_str(default_port);
                 }
                 host
             })

--- a/src/http_tunnel_codec.rs
+++ b/src/http_tunnel_codec.rs
@@ -120,11 +120,10 @@ impl TunnelTarget for HttpTunnelTarget {
         self.nugget.is_some()
     }
 
-    fn nugget(&self) -> Nugget {
+    fn nugget(&self) -> &Nugget {
         self.nugget
             .as_ref()
             .expect("Cannot use this method without checking `has_nugget`")
-            .clone()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@
 extern crate derive_builder;
 #[macro_use]
 extern crate serde_derive;
-extern crate strum;
-#[macro_use]
-extern crate strum_macros;
 
 use log::{error, info, LevelFilter};
 use rand::{thread_rng, Rng};
@@ -200,6 +197,7 @@ async fn serve_tcp(
                     match connector
                         .connect(&HttpTunnelTarget {
                             target: destination_copy,
+                            nugget: None,
                         })
                         .await
                     {

--- a/src/proxy_target.rs
+++ b/src/proxy_target.rs
@@ -84,7 +84,7 @@ where
             if target.has_nugget() {
                 if let Ok(written_successfully) = timeout(
                     self.connect_timeout,
-                    stream.write_all(&target.nugget().data),
+                    stream.write_all(&target.nugget().data()),
                 )
                 .await
                 {
@@ -198,5 +198,9 @@ impl Nugget {
         Self {
             data: Arc::new(v.into()),
         }
+    }
+
+    pub fn data(&self) -> Arc<Vec<u8>> {
+        self.data.clone()
     }
 }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -19,11 +19,12 @@ use crate::relay::{Relay, RelayBuilder, RelayPolicy, RelayStats};
 use core::fmt;
 use futures::stream::SplitStream;
 use std::fmt::Display;
+use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Nugget {
-    data: Vec<u8>,
+    data: Arc<Vec<u8>>,
 }
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize)]
@@ -76,7 +77,7 @@ pub trait TunnelTarget {
     type Addr;
     fn target_addr(&self) -> Self::Addr;
     fn has_nugget(&self) -> bool;
-    fn nugget(&self) -> Nugget;
+    fn nugget(&self) -> &Nugget;
 }
 
 /// We need to be able to trace events in logs/metrics.
@@ -318,10 +319,12 @@ pub async fn relay_connections<
 
 impl Nugget {
     pub fn new<T: Into<Vec<u8>>>(v: T) -> Self {
-        Self { data: v.into() }
+        Self {
+            data: Arc::new(v.into()),
+        }
     }
 
-    pub fn data(self) -> Vec<u8> {
+    pub fn data(self) -> Arc<Vec<u8>> {
         self.data
     }
 }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -14,18 +14,12 @@ use tokio::time::timeout;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
 use crate::configuration::TunnelConfig;
-use crate::proxy_target::TargetConnector;
+use crate::proxy_target::{Nugget, TargetConnector};
 use crate::relay::{Relay, RelayBuilder, RelayPolicy, RelayStats};
 use core::fmt;
 use futures::stream::SplitStream;
 use std::fmt::Display;
-use std::sync::Arc;
 use std::time::Duration;
-
-#[derive(Eq, PartialEq, Debug, Clone)]
-pub struct Nugget {
-    data: Arc<Vec<u8>>,
-}
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize)]
 #[allow(dead_code)]
@@ -315,18 +309,6 @@ pub async fn relay_connections<
         upstream_stats: Some(upstream_stats),
         downstream_stats: Some(downstream_stats),
     })
-}
-
-impl Nugget {
-    pub fn new<T: Into<Vec<u8>>>(v: T) -> Self {
-        Self {
-            data: Arc::new(v.into()),
-        }
-    }
-
-    pub fn data(self) -> Arc<Vec<u8>> {
-        self.data
-    }
 }
 
 // cov:begin-ignore-line
@@ -676,6 +658,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg(not(feature = "plain_text"))]
     async fn test_tunnel_not_allowed() {
         let handshake_request = b"GET foo.bar:80 HTTP/1.1\r\n\r\n";
         let handshake_response = b"HTTP/1.1 405 NOT_ALLOWED\r\n\r\n";


### PR DESCRIPTION
Added an ability to proxy plain text HTTP workloads. 
It requires enabling the `plain_text` feature and is generally discouraged due to privacy/security concerns.

See https://github.com/xnuter/http-tunnel/issues/6

