### PR TITLE
chore: add tcp command in error message

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -150,7 +150,7 @@ impl ProxyConfiguration {
             );
             ProxyMode::TCP(destination)
         } else {
-            unreachable!("Only http and https commands are supported");
+            unreachable!("Only http and https and tcp commands are supported");
         };
 
         let tunnel_config = match config {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -150,7 +150,7 @@ impl ProxyConfiguration {
             );
             ProxyMode::TCP(destination)
         } else {
-            unreachable!("Only http and https and tcp commands are supported");
+            unreachable!("Only http, https and tcp commands are supported");
         };
 
         let tunnel_config = match config {


### PR DESCRIPTION
Thanks for your great L4 or L7 tunnel!.

When I executed and read codes, I found very nits points.
`http-tunnel` has 3 subcommands, but error message says it supports only http and https subcommand.

```
-> % ./target/debug/http-tunnel -h
Simple HTTP(S) Tunnel 0.1.0

Eugene Retunsky

A simple HTTP(S) tunnel

USAGE:
    http-tunnel [OPTIONS] --bind <BIND> [SUBCOMMAND]

FLAGS:
    -h, --help       Print help information
    -V, --version    Print version information

OPTIONS:
        --bind <BIND>        Bind address, e.g. 0.0.0.0:8443
        --config <CONFIG>    Configuration file

SUBCOMMANDS:
    help     Print this message or the help of the given subcommand(s)
    http     Run the tunnel in HTTP mode
    https    Run the tunnel in HTTPS mode
    tcp      Run the tunnel in TCP proxy mode
```

Sincerely